### PR TITLE
Fix Python's SSL sockets erroring out

### DIFF
--- a/std/python/lib/ssl/Errors.hx
+++ b/std/python/lib/ssl/Errors.hx
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package python.lib.ssl;
+
+@:pythonImport("ssl", "SSLWantReadError")
+extern class SSLWantReadError {}
+
+@:pythonImport("ssl", "SSLWantWriteError")
+extern class SSLWantWriteError {}


### PR DESCRIPTION
This fixes an ancient bug relating python's SSL sockets.
I'm not sure how to put it into words, but SSLWantReadError and SSLWantWriteFunction can happen at anytime, and can be safely ignored.